### PR TITLE
Load pre-trained word embeddings for input and output

### DIFF
--- a/data_generator.py
+++ b/data_generator.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 BOS = "<S>"  # index 1
 EOS = "<E>"  # index 2
 PAD = "<P>"  # index 0
+UNK = "<U>"  # index 3
 
 # Dimensionality of image feature vector
 IMG_FEATS = 4096
@@ -701,7 +702,7 @@ class VisualWordDataGenerator(object):
 
         return longest_sentence
 
-    def extract_vocabulary(self):
+    def extract_vocabulary(self, unk_token=False):
         '''
         Collect word frequency counts over the train / val inputs and use
         these to create a model vocabulary. Words that appear fewer than
@@ -727,6 +728,8 @@ class VisualWordDataGenerator(object):
         # vocabulary is a word:id dict (superceded by/identical to word2index?)
         # <S>, <E> are special first indices
         vocabulary = {PAD: 0, BOS: 1, EOS: 2}
+	if unk_token:
+	    vocabulary[UNK] = 3
         for v in self.unk_dict:
             if self.unk_dict[v] > self.unk:
                 vocabulary[v] = len(vocabulary)

--- a/models.py
+++ b/models.py
@@ -42,7 +42,12 @@ class NIC:
         self.weights = options.init_from_checkpoint  # initialise with checkpointed weights?
         self.transfer_img_emb = options.transfer_img_emb
 
-    def buildKerasModel(self, use_sourcelang=False, use_image=True, embeddings=None, init_output=False):
+    def buildKerasModel(self, 
+                        use_sourcelang=False, 
+                        use_image=True, 
+                        embeddings=None, 
+                        init_output=False,
+                        fix_weights=False):
         '''
         Define the exact structure of your model here. We create an image
         description generation model by merging the VGG image features with
@@ -63,6 +68,7 @@ class NIC:
                              W_regularizer=l2(self.l2reg),
                              weights=[embeddings],
                              mask_zero=True,
+                             trainable=not fix_weights,
                              name="w_embed")(text_input)
         else:
             wemb = Embedding(output_dim=self.embed_size,

--- a/models.py
+++ b/models.py
@@ -56,7 +56,7 @@ class NIC:
         print(text_input._keras_shape)
 
         # Word embeddings
-        if embeddings:
+        if embeddings is not None:
             wemb = Embedding(output_dim=self.embed_size,
                              input_dim=self.vocab_size,
                              input_length=self.max_t,

--- a/models.py
+++ b/models.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class NIC:
 
-    def __init__(self, options):
+    def __init__(self, options, embeddings=None):
         self.max_t = options.max_t  # Expected timesteps. Needed to build the Theano graph
 
         # Model hyperparameters
@@ -39,6 +39,7 @@ class NIC:
         self.epsilon = 1e-8
         self.clipnorm = options.clipnorm
 
+        self.embeddings = embeddings
         self.weights = options.init_from_checkpoint  # initialise with checkpointed weights?
         self.transfer_img_emb = options.transfer_img_emb
 

--- a/models.py
+++ b/models.py
@@ -56,12 +56,21 @@ class NIC:
         print(text_input._keras_shape)
 
         # Word embeddings
-        wemb = Embedding(output_dim=self.embed_size,
-                         input_dim=self.vocab_size,
-                         input_length=self.max_t,
-                         W_regularizer=l2(self.l2reg),
-                         mask_zero=True,
-                         name="w_embed")(text_input)
+        if embeddings:
+            wemb = Embedding(output_dim=self.embed_size,
+                             input_dim=self.vocab_size,
+                             input_length=self.max_t,
+                             W_regularizer=l2(self.l2reg),
+                             weights=[embeddings],
+                             mask_zero=True,
+                             name="w_embed")(text_input)
+        else:
+            wemb = Embedding(output_dim=self.embed_size,
+                             input_dim=self.vocab_size,
+                             input_length=self.max_t,
+                             W_regularizer=l2(self.l2reg),
+                             mask_zero=True,
+                             name="w_embed")(text_input)
 
         drop_wemb = Dropout(self.dropin, name="wemb_drop")(wemb)
 

--- a/models.py
+++ b/models.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 
 class NIC:
 
-    def __init__(self, options, embeddings=None):
+    def __init__(self, options):
         self.max_t = options.max_t  # Expected timesteps. Needed to build the Theano graph
 
         # Model hyperparameters
@@ -39,11 +39,10 @@ class NIC:
         self.epsilon = 1e-8
         self.clipnorm = options.clipnorm
 
-        self.embeddings = embeddings
         self.weights = options.init_from_checkpoint  # initialise with checkpointed weights?
         self.transfer_img_emb = options.transfer_img_emb
 
-    def buildKerasModel(self, use_sourcelang=False, use_image=True):
+    def buildKerasModel(self, use_sourcelang=False, use_image=True, embeddings=None, init_output=False):
         '''
         Define the exact structure of your model here. We create an image
         description generation model by merging the VGG image features with

--- a/models.py
+++ b/models.py
@@ -148,12 +148,20 @@ class NIC:
                                               input_dim=self.hidden_size,
                                               W_regularizer=l2(self.l2reg)),
                                         name='rnn_to_output')(rnn)
-        
-        output = TimeDistributed(Dense(output_dim=self.vocab_size,
-                                       input_dim=self.embed_size,
-                                       W_regularizer=l2(self.l2reg),
-                                       activation='softmax'),
-                                 name='output')(rnn_to_output)
+        if init_output:
+            output = TimeDistributed(Dense(output_dim=self.vocab_size,
+                                           input_dim=self.embed_size,
+                                           W_regularizer=l2(self.l2reg),
+                                           activation='softmax',
+                                           weights=[embeddings.T]),
+                                           trainable=not fix_weights,
+                                     name='output')(rnn_to_output)
+        else:
+            output = TimeDistributed(Dense(output_dim=self.vocab_size,
+                                           input_dim=self.embed_size,
+                                           W_regularizer=l2(self.l2reg),
+                                           activation='softmax'),
+                                     name='output')(rnn_to_output)
 
 
         if self.optimiser == 'adam':

--- a/models.py
+++ b/models.py
@@ -144,11 +144,17 @@ class NIC:
                       U_regularizer=l2(self.l2reg),
                       name='rnn')([emb_to_hidden, rnn_initialisation])
 
+        rnn_to_output = TimeDistributed(Dense(output_dim=self.embed_size,
+                                              input_dim=self.hidden_size,
+                                              W_regularizer=l2(self.l2reg)),
+                                        name='rnn_to_output')(rnn)
+        
         output = TimeDistributed(Dense(output_dim=self.vocab_size,
-                                       input_dim=self.hidden_size,
+                                       input_dim=self.embed_size,
                                        W_regularizer=l2(self.l2reg),
                                        activation='softmax'),
-                                       name='output')(rnn)
+                                 name='output')(rnn_to_output)
+
 
         if self.optimiser == 'adam':
             # allow user-defined hyper-parameters for ADAM because it is

--- a/train.py
+++ b/train.py
@@ -206,6 +206,7 @@ if __name__ == "__main__":
     parser.add_argument("--init_output", action="store_true",
                         help="Also initialize output embeddings.")
     parser.add_argument("--binary_embeddings", action="store_true", help="Are embeddings in binary format?")
+    parser.add_argument("--fix_weights", action="store_true", help="Fix weights for the embeddings?")
 	
     # Model hyperparameters
     parser.add_argument("--batch_size", default=100, type=int)

--- a/train.py
+++ b/train.py
@@ -122,7 +122,7 @@ class GroundedTranslation(object):
             if self.args.existing_vocab != "":
                 self.data_generator.set_vocabulary(self.args.existing_vocab)
             else:
-                self.data_generator.extract_vocabulary()
+                self.data_generator.extract_vocabulary(unk_token=self.args.unk_token)
         self.args.vocab_size = self.data_generator.get_vocab_size()
 
         if not self.use_sourcelang:
@@ -208,7 +208,8 @@ if __name__ == "__main__":
                         help="Also initialize output embeddings.")
     parser.add_argument("--binary_embeddings", action="store_true", help="Are embeddings in binary format?")
     parser.add_argument("--fix_weights", action="store_true", help="Fix weights for the embeddings?")
-	
+    parser.add_argument("--unk_token", action="store_true", help="Use an unk token? If not specified the model skips them.")
+
     # Model hyperparameters
     parser.add_argument("--batch_size", default=100, type=int)
     parser.add_argument("--embed_size", default=256, type=int)

--- a/train.py
+++ b/train.py
@@ -57,18 +57,23 @@ class GroundedTranslation(object):
         '''
 	embedding_matrix = None
 	if self.args.init_embeddings:
-	    import gensim
+	    import gensim # To load the word embeddings.
+	    # Initialize a matrix with random values.
 	    embedding_matrix = np.random.rand(len(self.data_generator.word2index), self.args.embed_size)
+	    # Load word embeddings using Gensim.
 	    word_embeddings = gensim.models.KeyedVectors.load_word2vec_format(self.args.init_embeddings, 
 									      binary=self.args.binary_embeddings)
+	    logger.info("Loaded embeddings.")
+	    # Loop to fill the matrix with embeddings for each term in the vocabulary.
 	    for word,index in self.data_generator.word2index.items():
 	        if word not in {'<S>','<E>','<P>'}:
 		    try:
-		        embedding_vector = word_embeddings[word]
-		        embedding_matrix[index] = embedding_vector
-		    except KeyError:
+		        embedding_vector = word_embeddings[word]   # Get the word embedding from the loaded model.
+		        embedding_matrix[index] = embedding_vector # Add the word embedding to the matrix.
+		    except KeyError: # If the word is not in the loaded model.
 	                logger.info("No embedding found for %s" % word)
-	    logger.info("Loaded embeddings.")
+	    logger.info("Completed embedding matrix.")
+	    del word_embeddings # Save memory.
 	
         m = models.NIC(self.args)
         model = m.buildKerasModel(use_sourcelang=self.use_sourcelang,

--- a/train.py
+++ b/train.py
@@ -79,7 +79,8 @@ class GroundedTranslation(object):
         model = m.buildKerasModel(use_sourcelang=self.use_sourcelang,
                                   use_image=self.use_image,
 				  embeddings=embedding_matrix,
-				  init_output=self.args.init_output)
+				  init_output=self.args.init_output,
+				  fix_weights=self.args.fix_weights)
 
         callbacks = CompilationOfCallbacks(self.data_generator.word2index,
                                            self.data_generator.index2word,

--- a/train.py
+++ b/train.py
@@ -178,6 +178,13 @@ if __name__ == "__main__":
                         there are multiple feature vectors. Expects 'sum', \
                         'avg', or 'concat'.")
 
+    # Initialization options
+    parser.add_argument("--init_embeddings", default=None, type=str, help="Path to the\
+		embeddings (in word2vec format) to initialize the word embeddings in the model \
+		(defaults to None, i.e. randomly initialized embeddings).")
+    parser.add_argument("--init_output", action="store_true",
+                        help="Also initialize output embeddings.")
+	
     # Model hyperparameters
     parser.add_argument("--batch_size", default=100, type=int)
     parser.add_argument("--embed_size", default=256, type=int)


### PR DESCRIPTION
Here's the next update to the code. The embeddings are now initialisable for both input and output, using separate keywords.